### PR TITLE
[font-face] COLRv1 support in FF went stable in 107

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -122,14 +122,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.font_rendering.colr_v1.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "107",
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
COLRv1 support is shipped in FireFox since version 107. 

Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1791558
